### PR TITLE
Include Microsoft.Owin.Host.HttpListener

### DIFF
--- a/SharpLink/SharpLink.csproj
+++ b/SharpLink/SharpLink.csproj
@@ -32,6 +32,9 @@
       <HintPath>..\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Microsoft.Owin.Host.HttpListener">
+      <HintPath>..\packages\Microsoft.Owin.Host.HttpListener.3.0.1\lib\net45\Microsoft.Owin.Host.HttpListener.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
   </ItemGroup>


### PR DESCRIPTION
Fixes Microsoft.Owin.Host.HttpListener.dll not being added upon build.
